### PR TITLE
Fit a mixture of Gaussians with LR+D covariance structure using Factor Analysis EM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Arec Jamgochian <arec.jamgochian@terraai.earth> and contributors"]
 version = "1.0.0-DEV"
 
 [deps]
+Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GaussianMixtures = "cc18c42c-b769-54ff-9e2a-b28141a64aae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -12,6 +13,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+Clustering = "0.15.8"
 Distributions = "0.25.120"
 GaussianMixtures = "0.3.13"
 LinearAlgebra = "1.11.0"

--- a/examples/test_fitting.jl
+++ b/examples/test_fitting.jl
@@ -7,22 +7,33 @@ using Statistics
 using StructuredGaussianMixtures
 using Plots
 
+function mc_kl(p, q, n_samples=10000)
+    samples = rand(p, n_samples)
+    log_p = logpdf(p, samples)
+    log_q = logpdf(q, samples)
+    return mean(log_p .- log_q)
+end
+mc_jsd(p, q, n_samples=10000) = 0.5*(mc_kl(p, q, n_samples) + mc_kl(q, p, n_samples))
+
 function compare_methods_pca(true_gmm, n_components, n_rank; run_pca=true, n_samples=1000)
     data = rand(true_gmm, n_samples)
 
     # Fit using EM
+    @info "Fitting EM model"
     fitmethod = EM(n_components)
-    gmm_full = StructuredGaussianMixtures.fit(fitmethod, data)
+    @time gmm_full = StructuredGaussianMixtures.fit(fitmethod, data)
     gmm_full_samples = rand(gmm_full, n_samples)
 
     # Fit using PCAEM
+    @info "Fitting PCAEM model"
     fitmethod = PCAEM(n_components, n_rank)
-    gmm_pca = StructuredGaussianMixtures.fit(fitmethod, data)
+    @time gmm_pca = StructuredGaussianMixtures.fit(fitmethod, data)
     gmm_pca_samples = rand(gmm_pca, n_samples)
 
     # Fit using FactorEM
+    @info "Fitting FactorEM model"
     fitmethod = FactorEM(n_components, n_rank; initialization_method=:rand)
-    gmm_factor = StructuredGaussianMixtures.fit(fitmethod, data)
+    @time gmm_factor = StructuredGaussianMixtures.fit(fitmethod, data)
     gmm_factor_samples = rand(gmm_factor, n_samples)
 
     # plot samples from the three models
@@ -33,6 +44,11 @@ function compare_methods_pca(true_gmm, n_components, n_rank; run_pca=true, n_sam
         gmm_pca_samples = transform(pca, gmm_pca_samples)   
         gmm_factor_samples = transform(pca, gmm_factor_samples)
     end
+
+    # print the JSD between the true model and the three models
+    println("EM JSD: ", mc_jsd(true_gmm, gmm_full))
+    println("PCAEM JSD: ", mc_jsd(true_gmm, gmm_pca))
+    println("FactorEM JSD: ", mc_jsd(true_gmm, gmm_factor))
 
     # Create scatter plots of the three models
     xlabel = run_pca ? "PC1" : "Feature 1"
@@ -65,11 +81,6 @@ true_Ls = [randn(n_features, n_features) for _ in 1:n_components]
 true_covs = [true_Ls[i] * true_Ls[i]' for i in 1:n_components]
 true_gmm = MixtureModel(MvNormal.(true_means, true_covs), true_probs)
 compare_methods_pca(true_gmm, n_components, n_rank; run_pca=false)
-
-
-data = rand(true_gmm, 1000)
-StructuredGaussianMixtures.initialize_gmm(:rand, n_components, n_rank, data)
-
 
 # Low-Rank GMM with tied component ranks
 n_rank = 2

--- a/src/StructuredGaussianMixtures.jl
+++ b/src/StructuredGaussianMixtures.jl
@@ -1,3 +1,5 @@
+__precompile__(false)
+
 module StructuredGaussianMixtures
 
 using Distributions
@@ -7,6 +9,7 @@ using Random
 using MultivariateStats: PCA, fit as pca_fit, transform, reconstruct, projection, mean
 using GaussianMixtures
 import GaussianMixtures: covar
+using Clustering
 
 ## conversion to MixtureModel since GaussianMixtures.jl fails for d=1
 function Distributions.MixtureModel(gmm::GMM{T}) where {T<:AbstractFloat}

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -298,6 +298,10 @@ function e_step(gmm::MixtureModel, x::Matrix)
             log_resp[i, j] = logpdf(components(gmm)[j], x[:,i]) + log_weights[j]
         end
     end
+    
+    # Normalize log responsibilities in a numerically stable way
+    max_logs = maximum(log_resp, dims=2)
+    log_resp .-= max_logs .+ log.(sum(exp.(log_resp .- max_logs), dims=2))
     return log_resp
 end
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -250,7 +250,7 @@ function initialize_gmm(method::Symbol, n_components::Int, rank::Int, x::Matrix;
             if isempty(cluster_data)
                 # If cluster is empty, use small random initialization
                 μ = centers[:, k]
-                F = epsilon * randn(n_features, rank)
+                F = zeros(n_features, rank)
                 D = global_var
             else
                 # Compute mean and variance for this cluster
@@ -258,7 +258,7 @@ function initialize_gmm(method::Symbol, n_components::Int, rank::Int, x::Matrix;
                 D = var(cluster_data, dims=2)[:]
                 
                 # Initialize low-rank factor with small random values
-                F = epsilon * randn(n_features, rank)
+                F = zeros(n_features, rank)
             end
             components[k] = LRDMvNormal(μ, F, D)
             weights[k] = count(cluster_mask) / n_samples
@@ -274,7 +274,7 @@ function initialize_gmm(method::Symbol, n_components::Int, rank::Int, x::Matrix;
         components = Vector{LRDMvNormal}(undef, n_components)
         for k in 1:n_components
             μ = means[:, k]
-            F = epsilon * randn(n_features, rank)
+            F = zeros(n_features, rank)
             D = global_var
             components[k] = LRDMvNormal(μ, F, D)
         end

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -1,5 +1,5 @@
 """
-    predict(dist::MvNormal, x::AbstractVector, input_indices::Vector{Int}, output_indices::Vector{Int})
+    predict(dist::MvNormal, x::AbstractVector, input_indices::Union{Vector{Int},AbstractRange}, output_indices::Union{Vector{Int},AbstractRange})
 
 Compute the conditional distribution of the output indices given the input indices using the Schur complement.
 Returns a new MvNormal distribution representing the conditional distribution.
@@ -13,7 +13,7 @@ Returns a new MvNormal distribution representing the conditional distribution.
 # Returns
 - A new MvNormal distribution representing the conditional distribution
 """
-function predict(dist::MvNormal, x::AbstractVector, input_indices::Vector{Int}, output_indices::Vector{Int})
+function predict(dist::MvNormal, x::AbstractVector, input_indices::Union{Vector{Int},AbstractRange}, output_indices::Union{Vector{Int},AbstractRange})
     # Get the full mean and covariance
     μ = mean(dist)
     Σ = cov(dist)
@@ -44,7 +44,7 @@ function predict(dist::MvNormal, x::AbstractVector, input_indices::Vector{Int}, 
 end
 
 """
-    predict(dist::LRDMvNormal, x::AbstractVector, input_indices::Vector{Int}, output_indices::Vector{Int})
+    predict(dist::LRDMvNormal, x::AbstractVector, input_indices::Union{Vector{Int},AbstractRange}, output_indices::Union{Vector{Int},AbstractRange})
 
 Compute the conditional distribution of the output indices given the input indices using the Schur complement.
 Returns a new LRDMvNormal distribution representing the conditional distribution.
@@ -59,7 +59,7 @@ This implementation is efficient for low-rank plus diagonal covariance structure
 # Returns
 - A new LRDMvNormal distribution representing the conditional distribution
 """
-function predict(dist::LRDMvNormal, x::AbstractVector, input_indices::Vector{Int}, output_indices::Vector{Int})
+function predict(dist::LRDMvNormal, x::AbstractVector, input_indices::Union{Vector{Int},AbstractRange}, output_indices::Union{Vector{Int},AbstractRange})
     d = length(dist.μ)
     
     # Verify indices are valid
@@ -108,7 +108,7 @@ function predict(dist::LRDMvNormal, x::AbstractVector, input_indices::Vector{Int
 end
 
 """
-    marginal(dist::MvNormal, indices::Vector{Int})
+    marginal(dist::MvNormal, indices::Union{Vector{Int},AbstractRange})
 
 Compute the marginal distribution over the specified indices.
 Returns a new MvNormal distribution representing the marginal.
@@ -120,14 +120,14 @@ Returns a new MvNormal distribution representing the marginal.
 # Returns
 - A new MvNormal distribution representing the marginal
 """
-function marginal(dist::MvNormal, indices::Vector{Int})
+function marginal(dist::MvNormal, indices::Union{Vector{Int},AbstractRange})
     μ = mean(dist)[indices]
     Σ = cov(dist)[indices, indices]
     return MvNormal(μ, Σ)
 end
 
 """
-    marginal(dist::LRDMvNormal, indices::Vector{Int})
+    marginal(dist::LRDMvNormal, indices::Union{Vector{Int},AbstractRange})
 
 Compute the marginal distribution over the specified indices.
 Returns a new LRDMvNormal distribution representing the marginal.
@@ -139,7 +139,7 @@ Returns a new LRDMvNormal distribution representing the marginal.
 # Returns
 - A new LRDMvNormal distribution representing the marginal
 """
-function marginal(dist::LRDMvNormal, indices::Vector{Int})
+function marginal(dist::LRDMvNormal, indices::Union{Vector{Int},AbstractRange})
     
     μ = dist.μ[indices]
 
@@ -156,7 +156,7 @@ function marginal(dist::LRDMvNormal, indices::Vector{Int})
 end
 
 """
-    predict(dist::MultivariateMixture, x::AbstractVector, input_indices::Vector{Int}, output_indices::Vector{Int})
+    predict(dist::MultivariateMixture, x::AbstractVector, input_indices::Union{Vector{Int},AbstractRange}, output_indices::Union{Vector{Int},AbstractRange})
 
 Compute the conditional distribution of the output indices given the input indices for a mixture model.
 Returns a new mixture model where each component is the conditional distribution of the corresponding component,
@@ -171,7 +171,7 @@ and the weights are updated based on the log density of x under the marginal dis
 # Returns
 - A new mixture model representing the conditional distribution
 """
-function predict(dist::MultivariateMixture, x::AbstractVector, input_indices::Vector{Int}, output_indices::Vector{Int})
+function predict(dist::MultivariateMixture, x::AbstractVector, input_indices::Union{Vector{Int},AbstractRange}, output_indices::Union{Vector{Int},AbstractRange})
     # Get the number of components
     n_components = length(dist.components)
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,4 @@
 using StructuredGaussianMixtures
 using Test
 
-@testset "StructuredGaussianMixtures.jl" begin
-    # Write your tests here.
-end
+include("test_lrdmvnormal.jl")

--- a/test/test_lrdmvnormal.jl
+++ b/test/test_lrdmvnormal.jl
@@ -1,0 +1,142 @@
+using Test
+using LinearAlgebra
+using Random
+using Distributions
+using StructuredGaussianMixtures
+
+@testset "LRDMvNormal" begin
+    # Set random seed for reproducibility
+    Random.seed!(42)
+
+    # Test dimensions
+    n = 100  # dimension
+    r = 5    # rank
+
+    # Create test parameters
+    μ = randn(n)
+    F = randn(n, r)
+    D = abs.(randn(n)) .+ 1e-6  # ensure positive diagonal
+
+    # Create distribution
+    dist = LRDMvNormal(μ, F, D)
+
+    # Test basic properties
+    @test length(dist) == n
+    @test size(dist) == (n,)
+    @test eltype(dist) == Float64
+
+    # Test mean and covariance
+    @test mean(dist) ≈ μ
+    @test cov(dist) ≈ F * F' + Diagonal(D)
+
+    # Test logpdf with various inputs
+    @testset "logpdf" begin
+        # Test single point
+        x = randn(n)
+        logp = logpdf(dist, x)
+        @test isfinite(logp)
+        @test logp isa Float64
+
+        # Test multiple points
+        X = randn(n, 10)
+        logps = logpdf(dist, X)
+        @test size(logps) == (10,)
+        @test all(isfinite, logps)
+
+        # Test against MvNormal for small dimensions
+        small_n = 5
+        small_r = 2
+        small_μ = randn(small_n)
+        small_F = randn(small_n, small_r)
+        small_D = abs.(randn(small_n)) .+ 1e-6
+
+        small_dist = LRDMvNormal(small_μ, small_F, small_D)
+        small_mvn = MvNormal(small_μ, small_F * small_F' + Diagonal(small_D))
+        
+        small_x = randn(small_n)
+        @test logpdf(small_dist, small_x) ≈ logpdf(small_mvn, small_x) atol=1e-10
+
+        # Test edge cases
+        @test logpdf(dist, μ) > logpdf(dist, μ .+ 10)  # closer to mean should have higher probability
+        @test logpdf(dist, μ) > logpdf(dist, μ .- 10)
+
+        # Test with zero F (should reduce to diagonal normal)
+        zero_F_dist = LRDMvNormal(μ, zeros(n, r), D)
+        diag_mvn = MvNormal(μ, Diagonal(D))
+        @test cov(zero_F_dist) ≈ cov(diag_mvn)
+        @test logpdf(zero_F_dist, x) ≈ logpdf(diag_mvn, x) atol=1e-10
+
+        # Test against MvNormal for large dimensions
+        large_n = 1000
+        large_r = 10
+        large_μ = randn(large_n)
+        large_F = randn(large_n, large_r)
+        large_D = abs.(randn(large_n)) .+ 1e-6
+
+        large_dist = LRDMvNormal(large_μ, large_F, large_D)
+        large_mvn = MvNormal(large_μ, large_F * large_F' + Diagonal(large_D))
+        @test cov(large_dist) ≈ cov(large_mvn)
+        @test mean(large_dist) ≈ mean(large_mvn)
+        n_samples = 20
+        large_x = randn(large_n, n_samples)
+        full_pdfs = logpdf(large_mvn, large_x)
+        lrd_pdfs = logpdf(large_dist, large_x)
+        @test lrd_pdfs ≈ full_pdfs
+    end
+
+    # Test numerical stability
+    @testset "numerical stability" begin
+        # Test with very small D
+        small_D = fill(1e-10, n)
+        small_D_dist = LRDMvNormal(μ, F, small_D)
+        @test isfinite(logpdf(small_D_dist, μ))
+
+        # Test with very large D
+        large_D = fill(1e10, n)
+        large_D_dist = LRDMvNormal(μ, F, large_D)
+        @test isfinite(logpdf(large_D_dist, μ))
+
+        # Test with ill-conditioned F
+        ill_F = F .* 1e10
+        ill_D = D .* 1e-10
+        ill_dist = LRDMvNormal(μ, ill_F, ill_D)
+        @test isfinite(logpdf(ill_dist, μ))
+    end
+
+    # Test predict functionality
+    @testset "predict" begin
+        # Split dimensions
+        n1 = 50
+        n2 = n - n1
+        x1 = randn(n1)
+        
+        # Get conditional distribution
+        cond_dist = predict(dist, x1)
+        
+        # Test properties of conditional distribution
+        @test length(cond_dist) == n2
+        @test isfinite(logpdf(cond_dist, randn(n2)))
+        
+        # Test that conditional mean is correct
+        Σ11 = cov(dist)[1:n1, 1:n1]
+        Σ12 = cov(dist)[1:n1, n1+1:end]
+        Σ22 = cov(dist)[n1+1:end, n1+1:end]
+        expected_mean = μ[n1+1:end] + Σ12' * (Σ11 \ (x1 - μ[1:n1]))
+        @test mean(cond_dist) ≈ expected_mean atol=1e-10
+    end
+
+    # Test marginal functionality
+    @testset "marginal" begin
+        # Get marginal distribution
+        indices = 1:10
+        marg_dist = marginal(dist, indices)
+        
+        # Test properties of marginal distribution
+        @test length(marg_dist) == length(indices)
+        @test isfinite(logpdf(marg_dist, randn(length(indices))))
+        
+        # Test that marginal mean and covariance are correct
+        @test mean(marg_dist) ≈ μ[indices]
+        @test cov(marg_dist) ≈ cov(dist)[indices, indices]
+    end
+end 


### PR DESCRIPTION
This PR implements EM to fit a mixture of factor analyzers. Specifically, in the maximization step of GMM-fitting, we estimate the diagonal vector and factor components of each `LRDMvGaussian` in the mixture using an inner EM loop. This is done without ever forming the full covariance matrix.